### PR TITLE
Harden notification pipeline: strict auth/ownership checks, safe tag/query handling, and reminder guardrails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,4 @@ ModelManifest.xml
 /Infrastructure/pipelines/
 /.pipelines
 /NuGet.config
+/es-metadata.yml

--- a/Code/API/Notification.Service/Controllers/BaseController.cs
+++ b/Code/API/Notification.Service/Controllers/BaseController.cs
@@ -7,9 +7,11 @@ using System;
 using System.Linq;
 using System.Net.Mail;
 using BL.Common;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
+[Authorize]
 public class BaseController : ControllerBase
 {
     protected string Alias { get; set; }

--- a/Code/API/Notification.Service/Controllers/PushNotificationRegistrationController.cs
+++ b/Code/API/Notification.Service/Controllers/PushNotificationRegistrationController.cs
@@ -62,7 +62,7 @@ public class PushNotificationRegistrationController : BaseController
             }
 
             // Get registration
-            var registrations = await _pushNotificationRegistration.GetRegistrationInfo();
+            var registrations = await _pushNotificationRegistration.GetRegistrationInfo(Alias);
 
             // Log Success
             logData.EventDetails.Modify(Constant.AppAction, "Notification - Registration - Device Push - GET - Success");

--- a/Code/API/Notification.Service/Controllers/PushNotificationRegistrationController.cs
+++ b/Code/API/Notification.Service/Controllers/PushNotificationRegistrationController.cs
@@ -233,7 +233,7 @@ public class PushNotificationRegistrationController : BaseController
             }
 
             // Delete registration
-            await _pushNotificationRegistration.DeleteRegistration(id);
+            await _pushNotificationRegistration.DeleteRegistration(Alias, id);
 
             // Log Success
             logData.EventDetails.Modify(Constant.AppAction, "Notification - Registration - Device Push - DELETE - Success");

--- a/Code/API/Notification.Service/Helpers/PushNotificationRegistrationHelper.cs
+++ b/Code/API/Notification.Service/Helpers/PushNotificationRegistrationHelper.cs
@@ -3,6 +3,7 @@
 
 namespace Notification.Services.Helpers;
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -25,6 +26,10 @@ public class PushNotificationRegistrationHelper : IPushNotificationRegistration
     private readonly IConfiguration _config;
     private readonly NotificationHubClient _hub;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PushNotificationRegistrationHelper"/> class.
+    /// </summary>
+    /// <param name="config">The configuration containing notification hub connection settings.</param>
     public PushNotificationRegistrationHelper(IConfiguration config)
     {
         _config = config;
@@ -37,9 +42,10 @@ public class PushNotificationRegistrationHelper : IPushNotificationRegistration
     /// Gets the push registration info
     /// </summary>
     /// <returns>Returns the registration info if for the given user</returns>
-    public async Task<List<RegistrationDescription>> GetRegistrationInfo()
+    public async Task<List<RegistrationDescription>> GetRegistrationInfo(string alias)
     {
-        return (await _hub.GetAllRegistrationsAsync(0)).ToList();
+        string aliasTagPrefix = CreateAliasTagPrefix(alias);
+        return (await _hub.GetRegistrationsByTagAsync(aliasTagPrefix, 100)).ToList();
     }
 
     /// <summary>
@@ -106,8 +112,8 @@ public class PushNotificationRegistrationHelper : IPushNotificationRegistration
         // This insures that this registration is only for the currently signed in user's alias
         // The tag could contain anything else but that doesn't matter. The important thing is that it is of the form
         // [currentUsersAlias]_[type] and not [someOtherAlias]_[type] and this is an easy flexable way to test that
-        string aliasTagPrefix = string.Create(CultureInfo.InvariantCulture, $"{alias}_");
-        if (registrationInfo.Tags.Any(tag => !tag.StartsWith(aliasTagPrefix, System.StringComparison.OrdinalIgnoreCase)))
+        string aliasTagPrefix = CreateAliasTagPrefix(alias);
+        if (registrationInfo.Tags.Any(tag => !tag.StartsWith(aliasTagPrefix, StringComparison.OrdinalIgnoreCase)))
         {
             throw new InvalidDataException();
         }
@@ -172,10 +178,20 @@ public class PushNotificationRegistrationHelper : IPushNotificationRegistration
             throw new InvalidDataException();
         }
 
-        string aliasTagPrefix = string.Create(CultureInfo.InvariantCulture, $"{alias}_");
-        if (!existingRegistration.Tags.Any(tag => tag.StartsWith(aliasTagPrefix, System.StringComparison.OrdinalIgnoreCase)))
+        string aliasTagPrefix = CreateAliasTagPrefix(alias);
+        if (!existingRegistration.Tags.Any(tag => tag.StartsWith(aliasTagPrefix, StringComparison.OrdinalIgnoreCase)))
         {
             throw new InvalidDataException();
         }
+    }
+
+    /// <summary>
+    /// Creates a tag prefix by appending an underscore to the alias.
+    /// </summary>
+    /// <param name="alias">The alias to use as the base of the prefix.</param>
+    /// <returns>A string containing the alias followed by an underscore.</returns>
+    private static string CreateAliasTagPrefix(string alias)
+    {
+        return string.Create(CultureInfo.InvariantCulture, $"{alias}_");
     }
 }

--- a/Code/API/Notification.Service/Helpers/PushNotificationRegistrationHelper.cs
+++ b/Code/API/Notification.Service/Helpers/PushNotificationRegistrationHelper.cs
@@ -4,6 +4,7 @@
 namespace Notification.Services.Helpers;
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -105,10 +106,13 @@ public class PushNotificationRegistrationHelper : IPushNotificationRegistration
         // This insures that this registration is only for the currently signed in user's alias
         // The tag could contain anything else but that doesn't matter. The important thing is that it is of the form
         // [currentUsersAlias]_[type] and not [someOtherAlias]_[type] and this is an easy flexable way to test that
-        if (registrationInfo.Tags.Any(tag => !tag.Contains(alias)))
+        string aliasTagPrefix = string.Create(CultureInfo.InvariantCulture, $"{alias}_");
+        if (registrationInfo.Tags.Any(tag => !tag.StartsWith(aliasTagPrefix, System.StringComparison.OrdinalIgnoreCase)))
         {
             throw new InvalidDataException();
         }
+
+        await ValidateRegistrationOwnership(alias, registrationInfo.Id);
 
         registration.RegistrationId = registrationInfo.Id;
         registration.Tags = new HashSet<string>(registrationInfo.Tags);
@@ -126,10 +130,12 @@ public class PushNotificationRegistrationHelper : IPushNotificationRegistration
     /// <summary>
     /// Deletes the push registration entry in notification hub for the user/device combination
     /// </summary>
+    /// <param name="alias">Alias of the user</param>
     /// <param name="id">the registration id</param>
     /// <returns></returns>
-    public async Task DeleteRegistration(string id)
+    public async Task DeleteRegistration(string alias, string id)
     {
+        await ValidateRegistrationOwnership(alias, id);
         await _hub.DeleteRegistrationAsync(id);
     }
 
@@ -148,6 +154,28 @@ public class PushNotificationRegistrationHelper : IPushNotificationRegistration
             {
                 throw new HttpRequestException(HttpStatusCode.Gone.ToString());
             }
+        }
+    }
+
+    /// <summary>
+    /// Validates that the registration id belongs to the user alias by checking the tags of the registration entry in notification hub. If the registration doesn't exist or doesn't belong to the user then an exception is thrown
+    /// </summary>
+    /// <param name="alias">Alias of the user</param>
+    /// <param name="registrationId">The registration id</param>
+    /// <returns></returns>
+    /// <exception cref="InvalidDataException"></exception>
+    private async Task ValidateRegistrationOwnership(string alias, string registrationId)
+    {
+        var existingRegistration = await _hub.GetRegistrationAsync<RegistrationDescription>(registrationId);
+        if (existingRegistration?.Tags == null)
+        {
+            throw new InvalidDataException();
+        }
+
+        string aliasTagPrefix = string.Create(CultureInfo.InvariantCulture, $"{alias}_");
+        if (!existingRegistration.Tags.Any(tag => tag.StartsWith(aliasTagPrefix, System.StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new InvalidDataException();
         }
     }
 }

--- a/Code/API/Notification.Service/Interface/IPushNotificationRegistration.cs
+++ b/Code/API/Notification.Service/Interface/IPushNotificationRegistration.cs
@@ -8,13 +8,17 @@ using System.Threading.Tasks;
 using Contract;
 using Microsoft.Azure.NotificationHubs;
 
+/// <summary>
+/// Defines operations for managing push notification registrations in a notification hub.
+/// </summary>
 public interface IPushNotificationRegistration
 {
     /// <summary>
     /// Gets the push registration info
     /// </summary>
+    /// <param name="alias">Alias of the user</param>
     /// <returns>Returns the registration info if for the given user</returns>
-    Task<List<RegistrationDescription>> GetRegistrationInfo();
+    Task<List<RegistrationDescription>> GetRegistrationInfo(string alias);
 
     /// <summary>
     /// Creates the push registration id

--- a/Code/API/Notification.Service/Interface/IPushNotificationRegistration.cs
+++ b/Code/API/Notification.Service/Interface/IPushNotificationRegistration.cs
@@ -34,7 +34,8 @@ public interface IPushNotificationRegistration
     /// <summary>
     /// Deletes the push registration entry in notification hub for the user/device combination
     /// </summary>
+    /// <param name="alias">Alias of the user</param>
     /// <param name="id">the registration id</param>
     /// <returns></returns>
-    Task DeleteRegistration(string id);
+    Task DeleteRegistration(string alias, string id);
 }

--- a/Code/API/Notification.Service/Notification.Services.xml
+++ b/Code/API/Notification.Service/Notification.Services.xml
@@ -53,7 +53,13 @@
             Helper class to Create/Update/Delete push registration entry in notificationn hub
             </summary>
         </member>
-        <member name="M:Notification.Services.Helpers.PushNotificationRegistrationHelper.GetRegistrationInfo">
+        <member name="M:Notification.Services.Helpers.PushNotificationRegistrationHelper.#ctor(Microsoft.Extensions.Configuration.IConfiguration)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Notification.Services.Helpers.PushNotificationRegistrationHelper"/> class.
+            </summary>
+            <param name="config">The configuration containing notification hub connection settings.</param>
+        </member>
+        <member name="M:Notification.Services.Helpers.PushNotificationRegistrationHelper.GetRegistrationInfo(System.String)">
             <summary>
             Gets the push registration info
             </summary>
@@ -97,6 +103,13 @@
             <returns></returns>
             <exception cref="T:System.IO.InvalidDataException"></exception>
         </member>
+        <member name="M:Notification.Services.Helpers.PushNotificationRegistrationHelper.CreateAliasTagPrefix(System.String)">
+            <summary>
+            Creates a tag prefix by appending an underscore to the alias.
+            </summary>
+            <param name="alias">The alias to use as the base of the prefix.</param>
+            <returns>A string containing the alias followed by an underscore.</returns>
+        </member>
         <member name="T:Notification.Services.Helpers.WebPushNotificationRegistrationHelper">
             <summary>
             Helper class to Create/Update/Delete Web push registration entry in database
@@ -132,10 +145,16 @@
             <param name="registrationInfo">Registration details like browser/endpoint configuration</param>
             <returns></returns>
         </member>
-        <member name="M:Notification.Services.Interface.IPushNotificationRegistration.GetRegistrationInfo">
+        <member name="T:Notification.Services.Interface.IPushNotificationRegistration">
+            <summary>
+            Defines operations for managing push notification registrations in a notification hub.
+            </summary>
+        </member>
+        <member name="M:Notification.Services.Interface.IPushNotificationRegistration.GetRegistrationInfo(System.String)">
             <summary>
             Gets the push registration info
             </summary>
+            <param name="alias">Alias of the user</param>
             <returns>Returns the registration info if for the given user</returns>
         </member>
         <member name="M:Notification.Services.Interface.IPushNotificationRegistration.CreateRegistrationId(System.String)">

--- a/Code/API/Notification.Service/Notification.Services.xml
+++ b/Code/API/Notification.Service/Notification.Services.xml
@@ -74,10 +74,11 @@
             <param name="registrationInfo"></param>
             <returns>Returns all active registrations for the user</returns>
         </member>
-        <member name="M:Notification.Services.Helpers.PushNotificationRegistrationHelper.DeleteRegistration(System.String)">
+        <member name="M:Notification.Services.Helpers.PushNotificationRegistrationHelper.DeleteRegistration(System.String,System.String)">
             <summary>
             Deletes the push registration entry in notification hub for the user/device combination
             </summary>
+            <param name="alias">Alias of the user</param>
             <param name="id">the registration id</param>
             <returns></returns>
         </member>
@@ -86,6 +87,15 @@
             Checks if the exception has an internal response code of HttpStatusCode.Gone then throw a new HttpRequestException with HttpStatusCode as Gone
             </summary>
             <param name="e"></param>
+        </member>
+        <member name="M:Notification.Services.Helpers.PushNotificationRegistrationHelper.ValidateRegistrationOwnership(System.String,System.String)">
+            <summary>
+            Validates that the registration id belongs to the user alias by checking the tags of the registration entry in notification hub. If the registration doesn't exist or doesn't belong to the user then an exception is thrown
+            </summary>
+            <param name="alias">Alias of the user</param>
+            <param name="registrationId">The registration id</param>
+            <returns></returns>
+            <exception cref="T:System.IO.InvalidDataException"></exception>
         </member>
         <member name="T:Notification.Services.Helpers.WebPushNotificationRegistrationHelper">
             <summary>
@@ -143,10 +153,11 @@
             <param name="registrationInfo">Registration details like endpoint configuration</param>
             <returns></returns>
         </member>
-        <member name="M:Notification.Services.Interface.IPushNotificationRegistration.DeleteRegistration(System.String)">
+        <member name="M:Notification.Services.Interface.IPushNotificationRegistration.DeleteRegistration(System.String,System.String)">
             <summary>
             Deletes the push registration entry in notification hub for the user/device combination
             </summary>
+            <param name="alias">Alias of the user</param>
             <param name="id">the registration id</param>
             <returns></returns>
         </member>

--- a/Code/API/Notification.Service/Utils/AuthorizationMiddleware.cs
+++ b/Code/API/Notification.Service/Utils/AuthorizationMiddleware.cs
@@ -53,7 +53,7 @@ public class AuthorizationMiddleware : IMiddleware
 
             if (context.User != null)
             {
-                var appid = context.User.Claims.FirstOrDefault(c => c.Type.Equals("appid")) ?? context.User.Claims.FirstOrDefault(c => c.Type.Equals("aud"));
+                var appid = context.User.Claims.FirstOrDefault(c => c.Type.Equals("appid")) ?? context.User.Claims.FirstOrDefault(c => c.Type.Equals("azp"));
 
                 // if AppId is null or the AppId fetched from claims is different from the Valid AppId list value then return UnAuthorized Response
                 if (appid == null || !listOfValidAppIds.Any(id => id.Equals(appid.Value, StringComparison.InvariantCultureIgnoreCase)))

--- a/Code/API/Notification.Service/Utils/AuthorizationMiddleware.cs
+++ b/Code/API/Notification.Service/Utils/AuthorizationMiddleware.cs
@@ -66,6 +66,13 @@ public class AuthorizationMiddleware : IMiddleware
 
             #endregion Check for Valid AppID
         }
+        else
+        {
+            // If the request doesn't have the required headers added by App Service Authentication (EasyAuth) then return UnAuthorized Response
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            await context.Response.WriteAsync("Unauthorized request");
+            return;
+        }
 
         await next(context);
     }

--- a/Code/Core/Notification.BL.Common/Constant.cs
+++ b/Code/Core/Notification.BL.Common/Constant.cs
@@ -40,7 +40,7 @@ namespace Notification.BL.Common
         public const string CompanyName = "Microsoft";
         public const string Bearer = "Bearer";
         public const string ApplicationJson = "application/json";
-        public const string UserPrincipalName = "UserPrincipalName";
+        public const string UserPrincipalName = "X-MS-CLIENT-PRINCIPAL-NAME";
         public const string VapidDetails = "vapidDetails";
         public const string TTL = "TTL";
         public const string EndPoint = "EndPoint";

--- a/Code/Core/Notification.BL.Common/Helpers/NotificationHelper.cs
+++ b/Code/Core/Notification.BL.Common/Helpers/NotificationHelper.cs
@@ -229,12 +229,12 @@ namespace Notification.BL.Common.Helpers
         #region Private Methods
 
         /// <summary>
-        /// To update the mail status in Azure notification status table for scheduled email
+        /// To update the status in Azure notification status table for scheduled messages
         /// </summary>
         /// <param name="isSucccessfullySent"></param>
         /// <param name="item"></param>
         /// <returns></returns>
-        private async Task UpdateScheduledMailStatusInTable(bool isSucccessfullySent, NotificationItem item, string queue)
+        private async Task UpdateScheduledStatusInTable(bool isSucccessfullySent, NotificationItem item, string queue)
         {
             if (isSucccessfullySent)
             {
@@ -310,10 +310,12 @@ namespace Notification.BL.Common.Helpers
                     {
                         (isSucccessfullySent, item.SequenceNumber) = await SendMessage(failedQueuesInformation, logData, message, queue);
 
-                        //To handle scheduled email message
-                        if (queue.Equals(_config[Constant.MailQueueName], StringComparison.InvariantCultureIgnoreCase) && item.SequenceNumber > 0)
+                        // To handle scheduled email message
+                        if ((queue.Equals(_config[Constant.MailQueueName], StringComparison.InvariantCultureIgnoreCase)
+                            || queue.Equals(Constant.ReminderQueueName, StringComparison.InvariantCultureIgnoreCase))
+                            && item.SequenceNumber > 0)
                         {
-                            await UpdateScheduledMailStatusInTable(isSucccessfullySent, item, _config[Constant.MailQueueName]);
+                            await UpdateScheduledStatusInTable(isSucccessfullySent, item, queue);
                         }
                     }
 
@@ -322,6 +324,10 @@ namespace Notification.BL.Common.Helpers
                     {
                         message.ScheduledEnqueueTime = item.Reminder.NextReminderDate;
                         (isSucccessfullySent, item.SequenceNumber) = await SendMessage(failedQueuesInformation, logData, message, Constant.ReminderQueueName);
+                        if (item.SequenceNumber > 0)
+                        {
+                            await UpdateScheduledStatusInTable(isSucccessfullySent, item, Constant.ReminderQueueName);
+                        }
                     }
                     else
                     {

--- a/Code/Core/Notification.BL.Common/Helpers/NotificationHelper.cs
+++ b/Code/Core/Notification.BL.Common/Helpers/NotificationHelper.cs
@@ -5,6 +5,8 @@ namespace Notification.BL.Common.Helpers
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
     using System.Text.RegularExpressions;
     using System.Threading;
     using System.Threading.Tasks;
@@ -64,7 +66,7 @@ namespace Notification.BL.Common.Helpers
         public async Task<NotificationResponse> BroadcastNotificationsToProviders(NotificationItem item)
         {
             bool isSucccessfullySent;
-            Dictionary<string, string> failedQueuesInformation;
+            Dictionary<string, string> failedQueuesInformation = new Dictionary<string, string>();
             List<string> queueNames = new List<string>();
 
             foreach (var notificationItem in item.NotificationTypes)
@@ -92,7 +94,32 @@ namespace Notification.BL.Common.Helpers
                         break;
 
                     case NotificationType.Cancel:
-                        (isSucccessfullySent, failedQueuesInformation) = await CancelScheduledMessageAsync(Constant.ReminderQueueName, item);
+                        if (!string.IsNullOrWhiteSpace(item.Id))
+                        {
+                            var notificationStatusItems = _tableStorageHelper.GetTableEntityListByPartitionKey<NotificationStatus>(Constant.NotificationStatusTableName, item.Id);
+                            if (notificationStatusItems?.Count > 0)
+                            {
+                                var cancellationTasks = notificationStatusItems
+                                    .Where(statusItem => !string.IsNullOrWhiteSpace(statusItem.ScheduledSequenceNumberJson))
+                                    .Select(statusItem => JsonConvert.DeserializeObject<Dictionary<string, long>>(statusItem.ScheduledSequenceNumberJson))
+                                    .Where(sequenceNumbers => sequenceNumbers?.Count > 0)
+                                    .SelectMany(sequenceNumbers => sequenceNumbers.Select(kvp =>
+                                        CancelScheduledMessageAsync(kvp.Key, item, kvp.Value)))
+                                    .ToList();
+
+                                if (cancellationTasks.Count > 0)
+                                {
+                                    var results = await Task.WhenAll(cancellationTasks);
+
+                                    // Aggregate results
+                                    isSucccessfullySent = results.All(r => r.IsSuccess);
+                                    failedQueuesInformation = results
+                                        .SelectMany(r => r.FailedQueuesInformation)
+                                        .GroupBy(kvp => kvp.Key)
+                                        .ToDictionary(g => g.Key, g => g.First().Value);
+                                }
+                            }
+                        }
                         break;
                 }
             }
@@ -113,6 +140,21 @@ namespace Notification.BL.Common.Helpers
         {
             string output = templateContent;
             string data = Convert.ToString(templateData);
+            Dictionary<string, string> encodedTemplateData = null;
+
+            if (!string.IsNullOrWhiteSpace(data))
+            {
+                encodedTemplateData = JsonConvert.DeserializeObject<Dictionary<string, string>>(data)
+                    ?.ToDictionary(
+                        item => item.Key,
+                        item => WebUtility.HtmlEncode(item.Value ?? string.Empty));
+
+                if (encodedTemplateData != null)
+                {
+                    data = JsonConvert.SerializeObject(encodedTemplateData);
+                }
+            }
+
             if (null != notificationTypes)
             {
                 foreach (NotificationType notificationType in notificationTypes)
@@ -134,9 +176,9 @@ namespace Notification.BL.Common.Helpers
                 }
             }
 
-            if (data != null && output != null)
+            if (encodedTemplateData != null && output != null)
             {
-                foreach (KeyValuePair<string, string> replaceable in JsonConvert.DeserializeObject<Dictionary<string, string>>(data))
+                foreach (KeyValuePair<string, string> replaceable in encodedTemplateData)
                 {
                     output = output.Replace("#" + replaceable.Key + "#", replaceable.Value);
                 }
@@ -167,7 +209,7 @@ namespace Notification.BL.Common.Helpers
             {
                 logData.EventDetails.Modify(Constant.Xcv, $"{status.PartitionKey}");
 
-                return await _tableStorageHelper.Insert(tableName, status);
+                return await _tableStorageHelper.InsertOrReplace(tableName, status);
             }
             catch (Exception ex)
             {
@@ -185,6 +227,35 @@ namespace Notification.BL.Common.Helpers
         #endregion Public Methods
 
         #region Private Methods
+
+        /// <summary>
+        /// To update the mail status in Azure notification status table for scheduled email
+        /// </summary>
+        /// <param name="isSucccessfullySent"></param>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        private async Task UpdateScheduledMailStatusInTable(bool isSucccessfullySent, NotificationItem item, string queue)
+        {
+            if (isSucccessfullySent)
+            {
+                var scheduledEmailStatus = new NotificationStatus
+                {
+                    PartitionKey = item.Id,
+                    RowKey = item.Telemetry?.MessageId ?? item.Id,
+                    TenantIdentifier = item.TenantIdentifier,
+                    MessageId = item.Telemetry?.MessageId,
+                    Xcv = item.Telemetry?.Xcv,
+                    ActionResult = true,
+                    SequenceNumber = 0,
+                    ScheduledSequenceNumberJson = JsonConvert.SerializeObject(new Dictionary<string, long>()
+                    {
+                        { queue, item.SequenceNumber }
+                    })
+                };
+
+                await _tableStorageHelper.InsertOrReplace(Constant.NotificationStatusTableName, scheduledEmailStatus);
+            }
+        }
 
         /// <summary>
         /// Pushes the message to each of the service bus queue
@@ -238,6 +309,12 @@ namespace Notification.BL.Common.Helpers
                     foreach (var queue in queueNames)
                     {
                         (isSucccessfullySent, item.SequenceNumber) = await SendMessage(failedQueuesInformation, logData, message, queue);
+
+                        //To handle scheduled email message
+                        if (queue.Equals(_config[Constant.MailQueueName], StringComparison.InvariantCultureIgnoreCase) && item.SequenceNumber > 0)
+                        {
+                            await UpdateScheduledMailStatusInTable(isSucccessfullySent, item, _config[Constant.MailQueueName]);
+                        }
                     }
 
                     // Add to reminder queue if reminder notifications are applicable
@@ -289,7 +366,7 @@ namespace Notification.BL.Common.Helpers
         /// <param name="queue"></param>
         /// <param name="item"></param>
         /// <returns></returns>
-        private async Task<(bool IsSuccess, Dictionary<string, string> FailedQueuesInformation)> CancelScheduledMessageAsync(string queue, NotificationItem item)
+        private async Task<(bool IsSuccess, Dictionary<string, string> FailedQueuesInformation)> CancelScheduledMessageAsync(string queue, NotificationItem item, long sequenceNumber)
         {
             bool isSucccessfullySent = true;
             Dictionary<string, string> failedQueuesInformation = new Dictionary<string, string>();
@@ -312,10 +389,10 @@ namespace Notification.BL.Common.Helpers
             {
                 await _syncObject.WaitAsync();
 
-                if (item.SequenceNumber > 0)
+                if (sequenceNumber > 0)
                 {
                     // Cancel sending the scheduled message to the queue
-                    await _serviceBusClient.CreateSender(queue).CancelScheduledMessageAsync(item.SequenceNumber);
+                    await _serviceBusClient.CreateSender(queue).CancelScheduledMessageAsync(sequenceNumber);
                 }
             }
             catch (Exception ex)

--- a/Code/Core/Notification.Data.Azure.Storage/Helpers/TableHelper.cs
+++ b/Code/Core/Notification.Data.Azure.Storage/Helpers/TableHelper.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.Data.Tables;
@@ -18,6 +20,16 @@ namespace Notification.Data.Azure.Storage.Helpers
     /// </summary>
     public class TableHelper : ITableHelper
     {
+        private static readonly Regex FieldNameRegex = new Regex("^[A-Za-z_][A-Za-z0-9_]*$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static readonly HashSet<string> AllowedComparisonOperators = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "eq", "ne", "gt", "ge", "lt", "le"
+        };
+        private static readonly HashSet<string> AllowedLogicalOperators = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "and", "or"
+        };
+
         private readonly string _azureStorageAccountName;
         private readonly TokenCredential _tokenCredential;
 
@@ -63,7 +75,7 @@ namespace Notification.Data.Azure.Storage.Helpers
         public T GetTableEntityByRowKey<T>(string TableName, string rowKey) where T : class, ITableEntity, new()
         {
             TableClient tableClient = CreateTableClient(TableName);
-            return tableClient.Query<T>(filter: $"RowKey eq '{rowKey}'").FirstOrDefault();
+            return tableClient.Query<T>(entity => entity.RowKey == rowKey).FirstOrDefault();
         }
 
         /// <summary>
@@ -76,7 +88,7 @@ namespace Notification.Data.Azure.Storage.Helpers
         public T GetTableEntityByPartitionKey<T>(string TableName, string PartitionKey) where T : class, ITableEntity, new()
         {
             TableClient tableClient = CreateTableClient(TableName);
-            return tableClient.Query<T>(filter: $"PartitionKey eq '{PartitionKey}'").FirstOrDefault();
+            return tableClient.Query<T>(entity => entity.PartitionKey == PartitionKey).FirstOrDefault();
         }
 
         /// <summary>
@@ -89,7 +101,7 @@ namespace Notification.Data.Azure.Storage.Helpers
         public List<T> GetTableEntityListByRowKey<T>(string TableName, string RowKey) where T : class, ITableEntity, new()
         {
             TableClient tableClient = CreateTableClient(TableName);
-            return tableClient.Query<T>(filter: $"RowKey eq '{RowKey}'").ToList();
+            return tableClient.Query<T>(entity => entity.RowKey == RowKey).ToList();
         }
 
         /// <summary>
@@ -102,7 +114,7 @@ namespace Notification.Data.Azure.Storage.Helpers
         public List<T> GetTableEntityListByPartitionKey<T>(string TableName, string PartitionKey) where T : class, ITableEntity, new()
         {
             TableClient tableClient = CreateTableClient(TableName);
-            return tableClient.Query<T>(filter: $"PartitionKey eq '{PartitionKey}'").ToList();
+            return tableClient.Query<T>(entity => entity.PartitionKey == PartitionKey).ToList();
         }
 
         /// <summary>
@@ -116,7 +128,10 @@ namespace Notification.Data.Azure.Storage.Helpers
         public T GetTableEntityByfield<T>(string TableName, string fieldName, string fieldValue) where T : class, ITableEntity, new()
         {
             TableClient tableClient = CreateTableClient(TableName);
-            Pageable<T> queryResultsFilter = tableClient.Query<T>(filter: $"{fieldName} eq '{fieldValue}'");
+            string fieldNameToken = GetODataIdentifierToken(fieldName);
+            FormattableString queryFormattableString = FormattableStringFactory.Create($"{fieldNameToken} eq {{0}}", fieldValue);
+            string filter = TableClient.CreateQueryFilter(queryFormattableString);
+            Pageable<T> queryResultsFilter = tableClient.Query<T>(filter: filter);
             return queryResultsFilter.FirstOrDefault();
         }
 
@@ -131,7 +146,10 @@ namespace Notification.Data.Azure.Storage.Helpers
         public List<T> GetTableEntityListByfield<T>(string TableName, string fieldName, string fieldValue) where T : class, ITableEntity, new()
         {
             TableClient tableClient = CreateTableClient(TableName);
-            Pageable<T> queryResultsFilter = tableClient.Query<T>(filter: $"{fieldName} eq '{fieldValue}'");
+            string fieldNameToken = GetODataIdentifierToken(fieldName);
+            FormattableString queryFormattableString = FormattableStringFactory.Create($"{fieldNameToken} eq {{0}}", fieldValue);
+            string filter = TableClient.CreateQueryFilter(queryFormattableString);
+            Pageable<T> queryResultsFilter = tableClient.Query<T>(filter: filter);
             return queryResultsFilter?.ToList();
         }
 
@@ -160,7 +178,7 @@ namespace Notification.Data.Azure.Storage.Helpers
         public List<T> GetTableEntityListByPartitionKeyAndRowKey<T>(string TableName, string PartitionKey, string RowKey) where T : class, ITableEntity, new()
         {
             TableClient tableClient = CreateTableClient(TableName);
-            return tableClient.Query<T>(filter: $"PartitionKey eq '{PartitionKey}' and RowKey eq '{RowKey}'")?.ToList();
+            return tableClient.Query<T>(entity => entity.PartitionKey == PartitionKey && entity.RowKey == RowKey)?.ToList();
         }
 
         /// <summary>
@@ -260,7 +278,11 @@ namespace Notification.Data.Azure.Storage.Helpers
         public List<T> GetTableEntityByPartitionKeyAndField<T>(string TableName, string PartitionKey, string fieldName, string fieldValue) where T : class, ITableEntity, new()
         {
             TableClient tableClient = CreateTableClient(TableName);
-            Pageable<T> queryResultsFilter = tableClient.Query<T>(filter: $"PartitionKey eq '{PartitionKey}' and {fieldName} eq '{fieldValue}'");
+            string partitionKeyToken = GetODataIdentifierToken(nameof(ITableEntity.PartitionKey));
+            string fieldNameToken = GetODataIdentifierToken(fieldName);
+            FormattableString queryFormattableString = FormattableStringFactory.Create($"{partitionKeyToken} eq {{0}} and {fieldNameToken} eq {{1}}", PartitionKey, fieldValue);
+            string filter = TableClient.CreateQueryFilter(queryFormattableString);
+            Pageable<T> queryResultsFilter = tableClient.Query<T>(filter: filter);
             return queryResultsFilter?.ToList();
         }
 
@@ -271,10 +293,10 @@ namespace Notification.Data.Azure.Storage.Helpers
         /// <param name="TableName"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public List<T> GetDataCollectionByTableQuery<T>(string TableName, string query) where T : class, ITableEntity, new()
+        public List<T> GetDataCollectionByTableQuery<T>(string TableName, FormattableString query) where T : class, ITableEntity, new()
         {
             TableClient tableClient = CreateTableClient(TableName);
-            return tableClient.Query<T>(filter: query)?.ToList();
+            return tableClient.Query<T>(filter: TableClient.CreateQueryFilter(query))?.ToList();
         }
 
         /// <summary>
@@ -284,14 +306,15 @@ namespace Notification.Data.Azure.Storage.Helpers
         /// <param name="TableName"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public List<T> GetDataCollectionByTableQuerySegmented<T>(string TableName, string query) where T : class, ITableEntity, new()
+        public List<T> GetDataCollectionByTableQuerySegmented<T>(string TableName, FormattableString query) where T : class, ITableEntity, new()
         {
             List<T> result = new List<T>();
             TableClient tableClient = CreateTableClient(TableName);
             string continuationToken = null;
+            string filter = TableClient.CreateQueryFilter(query);
             do
             {
-                var responseList = tableClient.Query<T>(filter: query);
+                var responseList = tableClient.Query<T>(filter: filter);
                 foreach (var response in responseList.AsPages())
                 {
                     continuationToken = response.ContinuationToken;
@@ -315,7 +338,17 @@ namespace Notification.Data.Azure.Storage.Helpers
         public List<T> GetDataCollectionByColumns<T>(string TableName, KeyValuePair<string, string> columnOne, string columnOneQComparison, string tableOperator, KeyValuePair<string, string> columnTwo, string columnTwoQComparison) where T : class, ITableEntity, new()
         {
             TableClient tableClient = CreateTableClient(TableName);
-            var query = tableClient.Query<T>(filter: $"{columnOne.Key.ToString(CultureInfo.InvariantCulture)} {columnOneQComparison} '{columnOne.Value.ToString(CultureInfo.InvariantCulture)}' {tableOperator} {columnTwo.Key.ToString(CultureInfo.InvariantCulture)} {columnTwoQComparison} '{columnTwo.Value.ToString(CultureInfo.InvariantCulture)}'");
+            string leftFieldToken = GetODataIdentifierToken(columnOne.Key.ToString(CultureInfo.InvariantCulture));
+            string rightFieldToken = GetODataIdentifierToken(columnTwo.Key.ToString(CultureInfo.InvariantCulture));
+            string leftComparison = GetComparisonOperator(columnOneQComparison);
+            string rightComparison = GetComparisonOperator(columnTwoQComparison);
+            string logicalOperator = GetLogicalOperator(tableOperator);
+
+            FormattableString queryFormattableString = FormattableStringFactory.Create($"{leftFieldToken} {leftComparison} {{0}} {logicalOperator} {rightFieldToken} {rightComparison} {{1}}",
+                columnOne.Value.ToString(CultureInfo.InvariantCulture),
+                columnTwo.Value.ToString(CultureInfo.InvariantCulture));
+
+            var query = tableClient.Query<T>(filter: TableClient.CreateQueryFilter(queryFormattableString));
             return query.ToList();
         }
 
@@ -377,6 +410,55 @@ namespace Notification.Data.Azure.Storage.Helpers
             Entity.ETag = ETag.All;
             var response = await tableClient.UpdateEntityAsync(Entity, ETag.All, TableUpdateMode.Merge);
             return !response.IsError;
+        }
+
+        /// <summary>
+        /// Validates and returns the OData identifier token for the specified field name.
+        /// </summary>
+        /// <param name="fieldName">The field name to validate.</param>
+        /// <returns>The OData identifier token for the specified field name.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldName"/> is null, whitespace, or not a valid field name.</exception>
+        private static string GetODataIdentifierToken(string fieldName)
+        {
+            if (string.IsNullOrWhiteSpace(fieldName) || !FieldNameRegex.IsMatch(fieldName))
+            {
+                throw new ArgumentException("Invalid field name for query filter.", nameof(fieldName));
+            }
+
+            return $"[{fieldName}]";
+        }
+
+        /// <summary>
+        /// Validates and returns the specified comparison operator.
+        /// </summary>
+        /// <param name="comparisonOperator">The comparison operator to validate.</param>
+        /// <returns>The validated comparison operator.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="comparisonOperator"/> is null, whitespace, or not in the list of allowed comparison operators.</exception>
+        private static string GetComparisonOperator(string comparisonOperator)
+        {
+            if (string.IsNullOrWhiteSpace(comparisonOperator) || !AllowedComparisonOperators.Contains(comparisonOperator))
+            {
+                throw new ArgumentException("Invalid comparison operator for query filter.", nameof(comparisonOperator));
+            }
+
+            return comparisonOperator;
+        }
+
+        /// <summary>
+        /// Validates and returns the specified logical operator.
+        /// </summary>
+        /// <param name="tableOperator">The logical operator to validate.</param>
+        /// <returns>The validated logical operator.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="tableOperator"/> is null, whitespace, or not in the list of allowed logical
+        /// operators.</exception>
+        private static string GetLogicalOperator(string tableOperator)
+        {
+            if (string.IsNullOrWhiteSpace(tableOperator) || !AllowedLogicalOperators.Contains(tableOperator))
+            {
+                throw new ArgumentException("Invalid logical operator for query filter.", nameof(tableOperator));
+            }
+
+            return tableOperator;
         }
     }
 }

--- a/Code/Core/Notification.Data.Azure.Storage/Interface/ITableHelper.cs
+++ b/Code/Core/Notification.Data.Azure.Storage/Interface/ITableHelper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.Data.Tables;
@@ -35,9 +36,9 @@ namespace Notification.Data.Azure.Storage.Interface
 
         List<T> GetTableEntityByPartitionKeyAndField<T>(string TableName, string PartitionKey, string fieldName, string fieldValue) where T : class, ITableEntity, new();
 
-        List<T> GetDataCollectionByTableQuery<T>(string TableName, string query) where T : class, ITableEntity, new();
+        List<T> GetDataCollectionByTableQuery<T>(string TableName, FormattableString query) where T : class, ITableEntity, new();
 
-        List<T> GetDataCollectionByTableQuerySegmented<T>(string TableName, string query) where T : class, ITableEntity, new();
+        List<T> GetDataCollectionByTableQuerySegmented<T>(string TableName, FormattableString query) where T : class, ITableEntity, new();
 
         Task InsertOrReplaceRows<T>(string TableName, List<T> entities, bool caseConstraint = false) where T : class, ITableEntity, new();
 

--- a/Code/Model/Notification.Contract/NotificationItem.cs
+++ b/Code/Model/Notification.Contract/NotificationItem.cs
@@ -211,6 +211,10 @@ namespace Notification.Contract
     /// </summary>
     public class ReminderDetail
     {
+        public const int HardIterationCap = 30;
+        public const double MinimumFrequencyInHours = 1;
+        public const int MaximumExpirationWindowInDays = 30;
+
         /// <summary>
         /// Gets or sets the type of the notification.
         /// </summary>
@@ -228,6 +232,12 @@ namespace Notification.Contract
         /// </summary>
         [JsonProperty("frequency")]
         public double Frequency { get; set; }
+
+        /// <summary>
+        /// Gets or sets reminder iteration count.
+        /// </summary>
+        [JsonProperty("iterationCount")]
+        public int IterationCount { get; set; }
 
         /// <summary>
         /// Reminder Expiration Date.
@@ -253,6 +263,34 @@ namespace Notification.Contract
                     return (date != null && date <= ExpirationDate) ? (DateTime)date : DateTime.MinValue;
                 }
             }
+        }
+
+        /// <summary>
+        /// Checks if the reminder's frequency is valid as per the defined constraints.
+        /// </summary>
+        /// <returns>True if the reminder's frequency is valid, otherwise false.</returns>
+        public bool IsFrequencyValid()
+        {
+            return Frequency <= 0 || Frequency >= MinimumFrequencyInHours;
+        }
+
+        /// <summary>
+        /// Checks if the reminder's expiration date is within the allowed window.
+        /// </summary>
+        /// <param name="utcNow">The current UTC time.</param>
+        /// <returns>True if the expiration date is within the allowed window, otherwise false.</returns>
+        public bool IsExpirationWithinWindow(DateTime utcNow)
+        {
+            return ExpirationDate <= utcNow.AddDays(MaximumExpirationWindowInDays);
+        }
+
+        /// <summary>
+        /// Checks if the reminder has reached the hard iteration cap.
+        /// </summary>
+        /// <returns>True if the hard iteration cap is reached, otherwise false.</returns>
+        public bool HasReachedHardIterationCap()
+        {
+            return IterationCount >= HardIterationCap;
         }
     }
 

--- a/Code/Model/Notification.Contract/NotificationStatus.cs
+++ b/Code/Model/Notification.Contract/NotificationStatus.cs
@@ -21,5 +21,8 @@ namespace Notification.Contract
 
         [JsonProperty("sequenceNumber")]
         public long SequenceNumber { get; set; }
+
+        [JsonProperty("scheduledSequenceNumberJson")]
+        public string ScheduledSequenceNumberJson { get; set; } = string.Empty;
     }
 }

--- a/Code/Services/Notification.Function.CommonServices/CommonServicesStartup.cs
+++ b/Code/Services/Notification.Function.CommonServices/CommonServicesStartup.cs
@@ -89,6 +89,7 @@ public class CommonServicesStartup : FunctionsStartup
         var client = new BlobServiceClient(
                         new Uri($"https://" + config?[Constant.StorageAccountName] + ".blob.core.windows.net/"),
                         azureCredential);
+        builder.Services.AddSingleton<ITableHelper, TableHelper>((provider) => { return new TableHelper(config[Constant.StorageAccountName], azureCredential); });
         builder.Services.AddSingleton<INotificationHelper, NotificationHelper>();
         builder.Services.AddSingleton<IUtilityHelper, UtilityHelper>();
         builder.Services.AddSingleton<IPerformanceLogger, PerformanceLogger>();

--- a/Code/Services/Notification.Function.CommonServices/NotificationBroadcasterFunction.cs
+++ b/Code/Services/Notification.Function.CommonServices/NotificationBroadcasterFunction.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Claims;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using BL.Common;
 using BL.Common.Extension;
@@ -26,6 +27,9 @@ using Notification.Model.Model;
 /// </summary>
 public class NotificationBroadcasterFunction
 {
+    private static readonly Regex AliasRegex =
+        new("^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     private readonly INotificationHelper _notificationHelper;
     private readonly IAuthorizationMiddleware _authService;
 
@@ -75,6 +79,19 @@ public class NotificationBroadcasterFunction
             string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
             var data = JsonConvert.DeserializeObject<NotificationItem>(requestBody);
 
+            if (data?.NotificationTypes?.Contains(NotificationType.Text) == true && !IsValidAlias(data.To))
+            {
+                logData.EventDetails.Modify(Constant.AppAction, "Notification - Broadcaster - Failed - Invalid Text Alias");
+                logData.EventDetails.Modify(Constant.To, $"{data.To}");
+                using (logger.BeginScope(logData.EventDetails))
+                {
+                    logger.LogWarning(new EventId((int)EventIds.NotificationBroadcasterFailed),
+                        "Notification - Broadcaster - Failed - Invalid Text Alias");
+                }
+
+                return new BadRequestObjectResult("Invalid 'to' alias for Text notification.");
+            }
+
             logData.EventDetails.Modify(Constant.ApplicationName, $"{data.ApplicationName}");
             logData.EventDetails.Modify(Constant.TenantIdentifier, $"{data.TenantIdentifier}");
             logData.EventDetails.Modify(Constant.Xcv, $"{data.Telemetry?.Xcv}");
@@ -117,4 +134,7 @@ public class NotificationBroadcasterFunction
             return new BadRequestObjectResult(ex.Message);
         }
     }
+
+    private static bool IsValidAlias(string alias) =>
+        !string.IsNullOrWhiteSpace(alias) && AliasRegex.IsMatch(alias);
 }

--- a/Code/Services/Notification.Function.SendPushNotifications/Helpers/PushNotificationHelper.cs
+++ b/Code/Services/Notification.Function.SendPushNotifications/Helpers/PushNotificationHelper.cs
@@ -5,6 +5,7 @@ namespace Notification.Function.SendPushNotifications.Helpers;
 
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using BL.Common;
 using BL.Common.Extension;
@@ -21,6 +22,11 @@ using WebPush;
 
 public class PushNotificationHelper : IPushNotificationHelper
 {
+    private static readonly Regex NotificationToRegex =
+        new("^[A-Za-z0-9_@.-]{1,120}$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex InvalidTagExpressionCharactersRegex =
+        new("[\\s\\|&!()]", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     private readonly IConfiguration _config;
     private readonly ILogger _logger;
     private readonly string _vapidPublicKey;
@@ -183,6 +189,19 @@ public class PushNotificationHelper : IPushNotificationHelper
             }
         };
 
+        if (!IsValidNotificationTarget(notificationItem?.To))
+        {
+            logData.EventDetails.Modify(Constant.AppAction, "Notification - ProcessDevicePushNotificationRequestsAsync - Failed - Invalid To");
+            using (_logger.BeginScope(logData.EventDetails))
+            {
+                _logger.LogError(new EventId((int)EventIds.SendDevicePushNotificationError),
+                    new InvalidOperationException("Invalid notification target alias."),
+                    "Notification - ProcessDevicePushNotificationRequestsAsync - Failed - Invalid To");
+            }
+
+            return;
+        }
+
         foreach (var notificationType in notificationItem.NotificationTypes)
         {
             try
@@ -192,11 +211,12 @@ public class PushNotificationHelper : IPushNotificationHelper
                 foreach (var item in templateContent)
                 {
                     var payload = _notificationHelper.Replace(null, notificationItem.TemplateData, item.TemplateContent);
+                    var deviceTag = $"{notificationItem.To}{notificationType}";
                     switch (item.RowKey)
                     {
                         case "wns":
                             // Windows 8.1 / Windows Phone 8.1 / Windows 10
-                            NotificationOutcome wnsOutcome = await _hub.SendWindowsNativeNotificationAsync(payload, notificationItem.To + notificationType);
+                            NotificationOutcome wnsOutcome = await _hub.SendWindowsNativeNotificationAsync(payload, new[] { deviceTag });
 
                             // Log success
                             logData.EventDetails.Modify(Constant.AppAction, "Notification - ProcessDevicePushNotificationRequestsAsync - wns - Success");
@@ -209,7 +229,7 @@ public class PushNotificationHelper : IPushNotificationHelper
 
                         case "apns":
                             // iOS
-                            NotificationOutcome apnsOutcome = await _hub.SendAppleNativeNotificationAsync(payload, notificationItem.To + notificationType);
+                            NotificationOutcome apnsOutcome = await _hub.SendAppleNativeNotificationAsync(payload, new[] { deviceTag });
 
                             // Log success
                             logData.EventDetails.Modify(Constant.AppAction, "Notification - ProcessDevicePushNotificationRequestsAsync - apns - Success");
@@ -222,7 +242,7 @@ public class PushNotificationHelper : IPushNotificationHelper
 
                         case "fcm":
                             // Android
-                            NotificationOutcome fcmOutcome = await _hub.SendFcmNativeNotificationAsync(payload, notificationItem.To + notificationType);
+                            NotificationOutcome fcmOutcome = await _hub.SendFcmNativeNotificationAsync(payload, new[] { deviceTag });
 
                             // Log success
                             logData.EventDetails.Modify(Constant.AppAction, "Notification - ProcessDevicePushNotificationRequestsAsync - fcm - Success");
@@ -255,5 +275,17 @@ public class PushNotificationHelper : IPushNotificationHelper
             _logger.LogInformation(new EventId((int)EventIds.SendDevicePushNotificationCompleted),
                 "Notification - ProcessDevicePushNotificationRequestsAsync - Complete");
         }
+    }
+
+    /// <summary>
+    /// Check if the notification target alias is valid
+    /// </summary>
+    /// <param name="to">The notification target alias.</param>
+    /// <returns>True if the notification target alias is valid, otherwise false.</returns>
+    private static bool IsValidNotificationTarget(string to)
+    {
+        return !string.IsNullOrWhiteSpace(to)
+            && !InvalidTagExpressionCharactersRegex.IsMatch(to)
+            && NotificationToRegex.IsMatch(to);
     }
 }

--- a/Code/Services/Notification.Function.SendReminders/Helpers/ReminderNotificationHelper.cs
+++ b/Code/Services/Notification.Function.SendReminders/Helpers/ReminderNotificationHelper.cs
@@ -68,9 +68,30 @@ public class ReminderNotificationHelper : IReminderNotificationHelper
             // Set default response
             HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.BadRequest);
 
+            if (notificationItem?.Reminder == null)
+            {
+                throw new InvalidOperationException("Reminder details are required.");
+            }
+
+            if (!notificationItem.Reminder.IsFrequencyValid())
+            {
+                throw new InvalidOperationException($"Reminder frequency must be at least {ReminderDetail.MinimumFrequencyInHours} hour.");
+            }
+
+            if (!notificationItem.Reminder.IsExpirationWithinWindow(DateTime.UtcNow))
+            {
+                throw new InvalidOperationException($"Reminder expirationDate must be within {ReminderDetail.MaximumExpirationWindowInDays} days from now.");
+            }
+
+            if (notificationItem.Reminder.HasReachedHardIterationCap())
+            {
+                throw new InvalidOperationException($"Reminder iteration limit of {ReminderDetail.HardIterationCap} reached.");
+            }
+
             // Update payload to send only specific notifications for reminders
             notificationItem.NotificationTypes = notificationItem.Reminder.NotificationTypes;
             notificationItem.Subject = !notificationItem.Subject.StartsWith("Reminder") ? $"Reminder: {notificationItem.Subject}" : notificationItem.Subject;
+            notificationItem.Reminder.IterationCount++;
 
             // Send request
             response = await _httpHelper.SendRequestAsync(HttpMethod.Post, string.Empty, _functionUrl, JsonConvert.SerializeObject(notificationItem));

--- a/Code/Services/Notification.Function.SendReminders/SendRemindersNotification.cs
+++ b/Code/Services/Notification.Function.SendReminders/SendRemindersNotification.cs
@@ -39,7 +39,7 @@ public class SendRemindersNotification
     }
 
     [FunctionName("SendReminderNotification")]
-    public async Task Run([ServiceBusTrigger("%ReminderQueueName%", Connection = "ServiceBusNamespace")] ServiceBusMessage message, ILogger logger)
+    public async Task Run([ServiceBusTrigger("%ReminderQueueName%", Connection = "ServiceBusNamespace")] ServiceBusReceivedMessage message, ILogger logger)
     {
         LogData logData = new LogData()
         {

--- a/Code/Services/Notification.Function.SendReminders/SendRemindersStartup.cs
+++ b/Code/Services/Notification.Function.SendReminders/SendRemindersStartup.cs
@@ -88,6 +88,7 @@ public class SendRemindersStartup : FunctionsStartup
         var client = new BlobServiceClient(
                         new Uri($"https://" + config?[Constant.StorageAccountName] + ".blob.core.windows.net/"),
                         azureCredential);
+        builder.Services.AddScoped<INotificationHelper, NotificationHelper>();
         builder.Services.AddScoped<IReminderNotificationHelper, ReminderNotificationHelper>();
         builder.Services.AddScoped<IUtilityHelper, UtilityHelper>();
         builder.Services.AddSingleton<IPerformanceLogger, PerformanceLogger>();

--- a/Infrastructure/arm/logicapps/text/LogicApp.json
+++ b/Infrastructure/arm/logicapps/text/LogicApp.json
@@ -307,7 +307,7 @@
                 "method": "get",
                 "path": "/Tables/@{encodeURIComponent('UserPreferenceSetting')}/entities",
                 "queries": {
-                  "$filter": "@{concat('PartitionKey eq ''', triggerBody()?['to'], '''')}",
+                  "$filter": "@{concat('PartitionKey eq ''', replace(triggerBody()?['to'],'''',''''''), '''')}",
                   "$select": "PhoneNumber"
                 }
               }

--- a/NOTIFICATION_GUIDE.md
+++ b/NOTIFICATION_GUIDE.md
@@ -1,0 +1,305 @@
+# Notification Guide
+
+This guide explains how tenants can use the Notification Framework to send emails, schedule them for later, set up recurring reminders, and cancel pending notifications.
+
+## Sending an Email
+
+To send an email, POST to the `NotificationBroadcaster` endpoint with `notificationTypes` set to `"0"` (Mail) or `"1"` (Actionable Email).
+
+```json
+POST /api/NotificationBroadcaster
+{
+  "notificationTypes": ["0"],
+  "to": "recipient@domain.com",
+  "from": "sender@domain.com",
+  "subject": "Your expense has been submitted",
+  "body": "...",
+  "tenantIdentifier": "1",
+  "telemetry": {
+    "xcv": "some-correlation-id",
+    "messageId": "some-message-id"
+  }
+}
+```
+
+The email is sent immediately. The response confirms whether the request was accepted:
+
+```json
+{
+  "actionResult": true,
+  "displayMessage": "Message sent successfully",
+  "sequenceNumber": 0,
+  "telemetry": {
+    "xcv": "some-correlation-id",
+    "messageId": "some-message-id"
+  }
+}
+```
+
+## Scheduling an Email for Later
+
+To schedule an email to be sent at a specific time, include the `sendOnUtcDate` field. The email will be held and delivered at the specified UTC time.
+
+```json
+POST /api/NotificationBroadcaster
+{
+  "notificationTypes": ["0"],
+  "to": "recipient@domain.com",
+  "subject": "Monthly report is ready",
+  "sendOnUtcDate": "2025-02-15T09:00:00Z",
+  "tenantIdentifier": "1",
+  "telemetry": {
+    "xcv": "some-correlation-id",
+    "messageId": "some-message-id"
+  }
+}
+```
+
+> **Note:** Cancellation of scheduled emails is not currently supported. Once a scheduled email is queued, it will be delivered at the specified time.
+
+## Setting Up Reminder Emails
+
+Reminders allow you to send the same notification repeatedly at a set interval until an expiration date. This is useful for scenarios like pending approvals where the recipient needs periodic nudges.
+
+To set up reminders, include a `reminder` object in the payload:
+
+```json
+POST /api/NotificationBroadcaster
+{
+  "notificationTypes": ["0"],
+  "to": "approver@domain.com",
+  "subject": "Expense ER-123 needs your approval",
+  "tenantIdentifier": "1",
+  "reminder": {
+    "notificationTypes": ["0"],
+    "frequency": 24,
+    "expirationDate": "2025-03-01T00:00:00Z"
+  },
+  "telemetry": {
+    "xcv": "some-correlation-id",
+    "messageId": "some-message-id"
+  }
+}
+```
+
+### Reminder fields
+
+| Field | Description |
+|---|---|
+| `notificationTypes` | Which notification channels to use for reminders (e.g., `"0"` for email). This can differ from the initial notification. |
+| `frequency` | How often to send reminders, in **hours**. For example, `24` means once a day. |
+| `expression` | Alternatively, a CRON expression for more complex schedules (e.g., `"0 12 */10 * *"` for every 10 days at noon). Use either `frequency` or `expression`, not both. If `frequency` is greater than 0, it takes precedence. |
+| `expirationDate` | When to stop sending reminders (UTC). No reminders will be sent after this date. |
+
+### How it works
+
+1. The **first email** is sent immediately
+2. The **first reminder** is scheduled based on the `frequency` or `expression`
+3. When a reminder fires, a new email is sent with `"Reminder: "` prefixed to the subject
+4. The next reminder is automatically scheduled, repeating until the `expirationDate` is reached
+
+### Response
+
+The response includes a `sequenceNumber` and confirms whether the request was accepted:
+
+```json
+{
+  "actionResult": true,
+  "displayMessage": "Message sent successfully",
+  "sequenceNumber": 12345
+}
+```
+
+## Cancelling Reminders
+
+To stop a reminder chain, send a cancel request with the `id` from your original notification:
+
+```json
+POST /api/NotificationBroadcaster
+{
+  "notificationTypes": ["8"],
+  "id": "D7A224A3-0555-41CA-AB3F-FBA9A1EDBFF9",
+  "tenantIdentifier": "1",
+  "telemetry": {
+    "xcv": "some-correlation-id",
+    "messageId": "some-message-id"
+  }
+}
+```
+
+The system looks up the latest scheduled reminder internally using the `id`, so cancellation works regardless of how many reminder cycles have already passed.
+
+> **Note:** Emails and reminders that have already been delivered cannot be recalled.
+
+## Notification Types Reference
+
+| Value | Type | Description |
+|---|---|---|
+| `0` | Mail | Standard email |
+| `1` | ActionableEmail | Email with adaptive card content |
+| `2` | Tile | Device push (tile) |
+| `3` | Toast | Device push (toast) |
+| `4` | Badge | Device push (badge) |
+| `5` | Raw | Device push (raw) |
+| `6` | WebPush | Browser push notification |
+| `7` | Text | SMS/text notification |
+| `8` | Cancel | Cancel a scheduled reminder |
+
+## Payload Reference
+
+All requests are sent as a JSON POST to the `NotificationBroadcaster` endpoint. Below is the complete payload with all fields, followed by a description of each field and which notification types it applies to.
+
+### Full payload
+
+```json
+{
+  "notificationTypes": ["0"],
+  "id": "D7A224A3-0555-41CA-AB3F-FBA9A1EDBFF9",
+  "applicationName": "Expense",
+  "to": "recipient@domain.com",
+  "from": "sender@domain.com",
+  "cc": "cc-recipient@domain.com",
+  "bcc": "bcc-recipient@domain.com",
+  "subject": "Your expense has been submitted",
+  "body": "<html>...</html>",
+  "deeplinkUrl": "https://expense.contoso.com/details/123",
+  "webPushnotificationTag": "expense-tag-123",
+  "sendOnUtcDate": "2025-02-15T09:00:00Z",
+  "emailAccountNumberToUse": "0",
+  "culture": "en-US",
+  "tenantIdentifier": "1",
+  "templateId": "ExpenseSubmitted|None",
+  "templateData": {
+    "DocumentNumber": "ER-0000098473",
+    "TotalAmount": "123",
+    "TransactionCurrency": "USD"
+  },
+  "attachments": [
+    {
+      "fileName": "receipt.pdf",
+      "fileBase64": "base64-encoded-content",
+      "fileType": "application/pdf",
+      "fileUrl": "https://storageaccount.blob.core.windows.net/container/receipt.pdf",
+      "cid": "receipt-image-1"
+    }
+  ],
+  "reminder": {
+    "notificationTypes": ["0"],
+    "frequency": 24,
+    "expression": "0 12 */10 * *",
+    "expirationDate": "2025-03-01T00:00:00Z"
+  },
+  "sequenceNumber": 12345,
+  "telemetry": {
+    "xcv": "D7A224A3-0555-41CA-AB3F-FBA9A1EDBFF9",
+    "messageId": "562F3BAE-79F4-47E1-B21D-44B22673DBC8"
+  }
+}
+```
+
+### Field descriptions
+
+#### Common fields (all notification types)
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `notificationTypes` | `string[]` | Yes | Array of notification types to send. See [Notification Types Reference](#notification-types-reference). Multiple types can be specified to send the same notification across different channels. |
+| `id` | `string` | No | A unique identifier for the notification. Used for tracking, logging, and **required for cancelling reminders**. If you plan to cancel reminders, always include this. |
+| `applicationName` | `string` | No | Name of the calling application (e.g., `"Expense"`). Used for logging and as a label in push notifications. |
+| `tenantIdentifier` | `string` | Yes | Identifies the tenant. Used to partition data in blob storage and table storage. |
+| `sendOnUtcDate` | `datetime` | No | UTC date/time to schedule the notification for later delivery. If omitted or empty, the notification is sent immediately. |
+| `culture` | `string` | No | Culture/locale string (e.g., `"en-US"`). |
+| `telemetry` | `object` | Yes | Tracking identifiers for the notification. |
+| `telemetry.xcv` | `string` | Yes | Correlation vector for end-to-end tracing across services. |
+| `telemetry.messageId` | `string` | Yes | Unique message identifier for tracking individual notifications. |
+
+#### Email fields (`Mail`, `ActionableEmail`)
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `from` | `string` | No | Sender email address. |
+| `to` | `string` | Yes | Recipient email address. |
+| `cc` | `string` | No | CC recipient email address. |
+| `bcc` | `string` | No | BCC recipient email address. |
+| `subject` | `string` | Yes | Email subject line. |
+| `body` | `string` | No | Email body content (HTML supported). If using templates, this can be left empty. |
+| `templateId` | `string` | No | Identifier of the email template stored in Azure Table Storage (format: `TemplateName\|Variant`). |
+| `templateData` | `object` | No | Key-value pairs used to replace `#placeholders#` in the template content. |
+| `emailAccountNumberToUse` | `string` | No | Which email account to use for sending (default `"0"`). Useful when multiple accounts are configured to handle sending limits. |
+| `attachments` | `object[]` | No | Array of file attachments (see below). |
+
+#### Attachment fields (Email only)
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `fileName` | `string` | Yes | Name of the file (e.g., `"receipt.pdf"`). |
+| `fileBase64` | `string` | No | Base64-encoded file content. Use this **or** `fileUrl`, not both. |
+| `fileUrl` | `string` | No | Blob storage URL of the file. The framework will download and attach it automatically. Use this **or** `fileBase64`, not both. |
+| `fileType` | `string` | No | MIME type of the file (e.g., `"application/pdf"`). |
+| `cid` | `string` | No | Content ID for inline/embedded images in HTML email bodies. |
+
+#### Web Push fields (`WebPush`)
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `to` | `string` | Yes | User alias/email. Used to look up the user's registered push subscription endpoints. |
+| `subject` | `string` | Yes | Notification title displayed in the browser. |
+| `body` | `string` | Yes | Notification body text. |
+| `deeplinkUrl` | `string` | No | URL to open when the user clicks the notification. |
+| `webPushnotificationTag` | `string` | No | Tag for the notification. Notifications with the same tag replace each other in the browser. |
+
+#### Device Push fields (`Tile`, `Toast`, `Badge`, `Raw`)
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `to` | `string` | Yes | User alias/email. Used as a tag to target specific device registrations in Azure Notification Hub. |
+| `templateData` | `object` | Yes | Key-value pairs used to fill `#placeholders#` in the device notification templates stored in Azure Table Storage. |
+
+#### Text/SMS fields (`Text`)
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `to` | `string` | Yes | User alias/email. Used to look up the user's phone number from Azure Table Storage. |
+| `body` | `string` | Yes | Text message content. |
+
+#### Reminder fields (optional, works with any notification type)
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `reminder.notificationTypes` | `string[]` | Yes | Which channels to use for the reminder notifications. Can differ from the initial notification types. |
+| `reminder.frequency` | `number` | No | How often to send reminders, in hours (e.g., `24` = once a day). Takes precedence over `expression` if greater than 0. |
+| `reminder.expression` | `string` | No | CRON expression for complex schedules (e.g., `"0 12 */10 * *"`). Used only if `frequency` is 0 or not set. |
+| `reminder.expirationDate` | `datetime` | Yes | UTC date/time after which no more reminders will be sent. |
+
+#### Cancel fields (`Cancel`)
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | `string` | Yes | The notification `id` from the original request. The system looks up the latest scheduled reminder sequence number from this. |
+| `sequenceNumber` | `long` | No | Optional fallback. Only used if the `id` lookup fails (e.g., table unavailable). Not needed under normal circumstances. |
+
+### Response
+
+All requests return the following response:
+
+```json
+{
+  "tenantIdentifier": "1",
+  "actionResult": true,
+  "displayMessage": "Message sent successfully",
+  "sequenceNumber": 12345,
+  "telemetry": {
+    "xcv": "D7A224A3-0555-41CA-AB3F-FBA9A1EDBFF9",
+    "messageId": "562F3BAE-79F4-47E1-B21D-44B22673DBC8"
+  },
+  "e2EErrorInformation": null
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `actionResult` | `boolean` | `true` if the notification was successfully queued, `false` otherwise. |
+| `displayMessage` | `string` | Human-readable status message. |
+| `sequenceNumber` | `long` | Service Bus sequence number of the last scheduled message. Save this if you need to cancel a reminder later. For immediate (non-scheduled) notifications, this will be `0`. |
+| `telemetry` | `object` | Echo of the correlation identifiers from the request. |
+| `e2EErrorInformation` | `object` | Error details if `actionResult` is `false`. Contains `errorMessages` (list of failure descriptions), `errorType`, and `retryInterval`. |

--- a/README.md
+++ b/README.md
@@ -193,8 +193,46 @@ Once all the components are deployed, go to the below components, copy the acces
         Use 'IdentityProviderResource' value
     
     > appid
-    
+
         Use 'ManagedIdentityClientId' value
+
+#### Service Bus RBAC Role Assignments
+
+Each Function App uses Managed Identity to connect to Azure Service Bus. The following roles must be assigned on the Service Bus namespace (or individual queues) for each Function App's managed identity:
+
+| Function App | Role | Queue (App Setting) | Direction |
+|---|---|---|---|
+| **Notification Common Services** | Azure Service Bus Data Sender | `MailQueueName` | Sends email notifications |
+| | Azure Service Bus Data Sender | `DevicePushQueueName` | Sends device push notifications |
+| | Azure Service Bus Data Sender | `WebPushQueueName` | Sends web push notifications |
+| | Azure Service Bus Data Sender | `TextQueueName` | Sends text notifications |
+| | Azure Service Bus Data Sender | `ReminderQueueName` | Schedules/cancels reminder messages |
+| **Send Email Function App** | Azure Service Bus Data Receiver | `MailQueueName` | Receives email notifications |
+| **Send Reminder Function App** | Azure Service Bus Data Receiver | `ReminderQueueName` | Receives reminder notifications |
+| **Send Push Function App** | Azure Service Bus Data Receiver | `DevicePushQueueName` | Receives device push notifications |
+| | Azure Service Bus Data Receiver | `WebPushQueueName` | Receives web push notifications |
+| **Send Text Function App** | Azure Service Bus Data Receiver | `TextQueueName` | Receives text notifications |
+
+> **Note:** The *GetEmailNotificationStatus* Function App and *Notification Service API* do not require any Service Bus roles (they use Timer Trigger and HTTP respectively).
+
+#### Storage Account RBAC Role Assignments
+
+Each Function App and API uses Managed Identity to connect to Azure Storage. The following roles must be assigned on the Storage Account for each app's managed identity:
+
+| Function App / API | Storage Blob Data Contributor | Storage Blob Data Reader | Storage Table Data Contributor |
+|---|---|---|---|
+| **Notification Common Services** |✅ | | ✅ |
+| **Send Email Function App** |✅ | |✅ |
+| **Send Reminder Function App** |✅ | |✅ |
+| **Send Push Function App** | | | |
+| **Send Text Function App** | | | |
+| **Send Custom Notification** | | | |
+| **GetEmailNotificationStatus** |✅ | |✅|
+| **Notification Service API** | | | |
+
+- **Blob Data Contributor** is needed by Common Services because it **uploads** compressed notification payloads to blob storage before sending a Service Bus message reference.
+- **Blob Data Reader** is needed by the consumer Function Apps because they **download** the payload from blob storage when processing messages.
+- **Table Data Contributor** is needed by apps that read/write notification templates, notification status logs, push notification registrations, or scheduled message tracking in Azure Table Storage. Common Services uses it to persist and look up reminder sequence numbers for cancellation support.
 
 ## Local Setup
 Configure the following package sources in VS to restore NuGet packages:
@@ -214,6 +252,10 @@ If the issue persists, add the following AppSettings in the service configuratio
 ## How to Setup to use this framework
 
 See the [SETUP.md](SETUP.md) file for details
+
+## How to use Notifications
+
+See the [NOTIFICATION_GUIDE.md](NOTIFICATION_GUIDE.md) for details on sending emails, scheduling notifications, setting up reminders, and cancellation
 
 ## Authors
 


### PR DESCRIPTION
## Summary

This PR hardens the notification pipeline with stronger authentication/authorization, stricter ownership validation, safer query/tag handling, and reminder processing guardrails.

## What Changed

### Security & Authorization
- Enforced authenticated user identity from EasyAuth principal headers.
- Added/strengthened `[Authorize]` usage.
- Removed permissive `aud` fallback logic.
- Required verified `appid/azp` principal checks with explicit deny path (`401`) when validation fails.

### Registration Ownership Validation
- Replaced broad alias matching (`Contains`) with exact prefix-based ownership checks.
- On GET, filtered registrations to verified caller alias tags only.
- On PUT/DELETE, fetched existing registration and verified exact ownership before allowing mutation.

### Input Validation & Injection Safety
- Validated `notificationItem.To` with strict regex: `^[A-Za-z0-9_@.-]{1,120}$`.
- Rejected invalid characters (including whitespace and `| & ! ( )`) in `To`.
- Escaped single quotes in broadcaster path.
- HTML-encoded all `templateData` values before template substitution.

### Safer Azure Table Queries
- Replaced interpolated OData filter strings with:
  - Typed LINQ query overloads, and/or
  - `TableClient.CreateQueryFilter(FormattableString)` helper.

### Reminder Reliability Improvements
- Enforced minimum reminder frequency: `>= 1 hour`.
- Enforced maximum expiration window: `<= now + 30 days`.
- Added reminder iteration counter with hard cap.
- Persisted reminders queue sequence number in `NotificationStatus` so cancel operations can target the correct queued message.

## Impact

- Reduces risk of unauthorized registration updates/deletes.
- Improves safety against malformed input and query/tag injection vectors.
- Makes reminder scheduling/cancellation behavior more predictable and reliable.

## Potential Breaking Changes

- Requests that previously passed with weak/invalid identity claims may now return `401`.
- Nonconforming `To` values now fail validation.
- Registration updates/deletes now require strict ownership/tag verification and may be rejected if tags are not compliant.

## Testing Notes

- Verified auth failures return `401` when principal/app claims are missing or invalid.
- Verified registration GET/PUT/DELETE behavior with matching vs non-matching ownership tags.
- Verified invalid `To` inputs are rejected.
- Verified reminders enforce frequency/expiration constraints and cancel behavior with persisted sequence number.
- Verified table query paths use typed/filter-safe APIs without interpolated OData strings.